### PR TITLE
Add CWE-200 to list of bugs detectable by KMSAN

### DIFF
--- a/linux-kernel-defence-map.dot
+++ b/linux-kernel-defence-map.dot
@@ -251,6 +251,7 @@ digraph {
   "Double Free (CWE-415)" -> "KASAN";
   "Undefined Behaviour (CWE-758)" -> "UBSAN";
   "Uninitialized Vars (CWE-457)" -> "KMSAN";
+  "Info Exposure (CWE-200)" -> "KMSAN";
   "Race Condition (CWE-362)" -> "KTSAN";
 
 


### PR DESCRIPTION
To some extent, KMSAN can detect info exposures (aka information leaks). E.g. it reports copying of uninitialized stack/heap data to the userspace. See https://github.com/google/kmsan/wiki/KMSAN-Trophies for examples.